### PR TITLE
Suggested changes to CFPs

### DIFF
--- a/_pages/calls/industry.md
+++ b/_pages/calls/industry.md
@@ -56,16 +56,16 @@ Submissions to the industry track should be relevant to real-world application f
 ## Important dates
 The industry track will have the same deadlines as the research track.
 
-<table style="width: 60%">
+<table style="width: 90%">
     <tbody>
         <tr>
-            <td style="width: 40%;">Abstract submissions due<br/>(<i>long, short, &amp; industry track</i>)</td>
-            <td style="width: 30%;">Monday</td>
+            <td style="width: 50%;">Abstract submissions due<br/>(<i>long, short, &amp; industry track</i>)</td>
+            <td style="width: 15%;">Monday</td>
             <td>December 3, 2018</td>
         </tr>
         <tr>
-            <td style="width: 40%;">Final paper submissions due<br/>(<i>long, short, &amp; industry track</i>)</td>
-            <td style="width: 30%;">Monday</td>
+            <td>Final paper submissions due<br/>(<i>long, short, &amp; industry track</i>)</td>
+            <td>Monday</td>
             <td>December 10, 2018</td>
         </tr>
         <tr>
@@ -85,7 +85,10 @@ The industry track will have the same deadlines as the research track.
 
 ## Contact Information
 - Email: [naacl-2019-industry-track@googlegroups.com](mailto:naacl-2019-industry-track@googlegroups.com)
-- Industry track co-chairs: Rohit Kumar (Spotify), Anastassia Loukina (Educational Testing Service), and Michelle Morales (IBM)
+- Industry track co-chairs
+  - Rohit Kumar (Spotify)
+  - Anastassia Loukina (Educational Testing Service)
+  - Michelle Morales (IBM)
 - General chair: Jill Burstein (Educational Testing Service)
 
 ## Frequently Asked Questions
@@ -102,7 +105,7 @@ We are looking for applications that are deployed (or expected to be deployed) f
 
 Yes! If your work matches the industry track call for papers, consider submitting a paper to the industry track.
 
-**I work in the industry. Can I still submit my paper to the research track?***
+**I work in the industry. Can I still submit my paper to the research track?**
 
 Absolutely! There are no changes to the main conference submissions. The industry track offers a forum to submit papers describing aspects of real-world applications that may differ in focus from the research track reviewing criteria.
 

--- a/_pages/calls/papers.md
+++ b/_pages/calls/papers.md
@@ -56,7 +56,7 @@ As in recent years, some of the presentations at the conference will be of paper
 
 **Abstract Submission Will Be Required for Long and Short Papers**
 
-Paper submission will be a two-step process. Please read carefully. Step 1 is the *abstract submission process* that requires you to register the title, author list, abstract and keywords by **Dec 3, 2018** in the START system.  This will help us to accelerate matching papers with reviewers. Step 2 is the *long and short paper submission* which will be due on **December 10, 2018**. The title, author list, abstract and keywords may not be changed after Dec 3, 2018; if they change, the entry in START will not match the full paper when it is registered, and it will be rejected as not having met the Abstract deadline.
+Paper submission will be a two-step process. Please read carefully. Step 1 is the *abstract submission process* that requires you to register the title, author list, abstract and keywords by **December 3, 2018** in the START system.  This will help us to accelerate matching papers with reviewers. Step 2 is the *long and short paper submission* which will be due on **December 10, 2018**. The title, author list, abstract and keywords may not be changed after December 3, 2018; if they change, the entry in START will not match the full paper when it is registered, and it will be rejected as not having met the Abstract deadline.
 
 ### Long Papers
 
@@ -153,16 +153,16 @@ At least one author of each accepted paper must register for NAACL-HLT 2019 by t
 
 ### Important Dates
 
-<table style="width: 60%">
+<table style="width: 90%">
     <tbody>
         <tr>
-            <td style="width: 40%;">Abstract submissions due<br/>(<i>long, short, &amp; industry track</i>)</td>
-            <td style="width: 30%;">Monday</td>
+            <td style="width: 50%;">Abstract submissions due<br/>(<i>long, short, &amp; industry track</i>)</td>
+            <td style="width: 15%;">Monday</td>
             <td>December 3, 2018</td>
         </tr>
         <tr>
-            <td style="width: 40%;">Final paper submissions due<br/>(<i>long, short, &amp; industry track</i>)</td>
-            <td style="width: 30%;">Monday</td>
+            <td>Final paper submissions due<br/>(<i>long, short, &amp; industry track</i>)</td>
+            <td>Monday</td>
             <td>December 10, 2018</td>
         </tr>
         <tr>
@@ -183,5 +183,8 @@ At least one author of each accepted paper must register for NAACL-HLT 2019 by t
 ## Contact Information
 
 - Email: [naacl-2019-program-chairs@googlegroups.com](mailto:naacl-2019-program-chairs@googlegroups.com)
-- Program co-chairs: Christy Doran (Interactions), Ted Pedersen (University of Minnesota Duluth) and Thamar Solorio (University of Houston)
+- Program co-chairs
+  - Christy Doran (Interactions)
+  - Ted Pedersen (University of Minnesota Duluth)
+  - Thamar Solorio (University of Houston)
 - General chair: Jill Burstein (Educational Testing Service)


### PR DESCRIPTION
1. The important dates table is cramped in both CFPs. Increased the table width.
2. Lingering asterik in one of the FAQ in industry track CFP. Removed.
3. In Research track CFP, December and abbrv. Dec are both both in Submission types paragraph. Changed to December to be stylistically consistent.
4. Co-chairs listed as sub-bullets.